### PR TITLE
BAH-1861  Upgrade openmrs version from 2.4.2 to 2.5.0 in openmrs-atomfeed module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 	</modules>
 	
 	<properties>
-		<openMRSVersion>2.4.2</openMRSVersion>
+		<openMRSVersion>2.5.0</openMRSVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <atomfeed.version>1.10.1</atomfeed.version>
 		<log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
### Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1861
Upgraded openMRSVersion to 2.5.0

### Solution
Add missing dependencies that have been generated due to version upgrade.

## The following changes have been made:

- udpated
openMRS v2.4.2 -> 2.5.0


### Testing
The screenshots for successful compilation have been added on the ticket.