### PR TITLE
BAH-4681 | Fix. Atomfeed feed API failure due to missing privilege

### DIFF
--- a/openmrs-atomfeed-api/pom.xml
+++ b/openmrs-atomfeed-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.ict4h.openmrs</groupId>
 		<artifactId>openmrs-atomfeed</artifactId>
-		<version>2.6.3</version>
+		<version>2.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>openmrs-atomfeed-api</artifactId>

--- a/openmrs-atomfeed-common/pom.xml
+++ b/openmrs-atomfeed-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ict4h.openmrs</groupId>
         <artifactId>openmrs-atomfeed</artifactId>
-        <version>2.6.3</version>
+        <version>2.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openmrs-atomfeed-common</artifactId>

--- a/openmrs-atomfeed-omod/pom.xml
+++ b/openmrs-atomfeed-omod/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.ict4h.openmrs</groupId>
 		<artifactId>openmrs-atomfeed</artifactId>
-		<version>2.6.3</version>
+		<version>2.7.0-SNAPSHOT</version>
 	</parent>
 
     <scm>

--- a/openmrs-atomfeed-omod/src/main/java/org/openmrs/module/atomfeed/utils/UrlUtil.java
+++ b/openmrs-atomfeed-omod/src/main/java/org/openmrs/module/atomfeed/utils/UrlUtil.java
@@ -21,7 +21,9 @@ public class UrlUtil {
     }
 
     private String getBaseUrlFromOpenMrsGlobalProperties(HttpServletRequest request) {
+        Context.addProxyPrivilege(org.openmrs.util.PrivilegeConstants.GET_GLOBAL_PROPERTIES);
         String restUri = Context.getAdministrationService().getGlobalProperty("webservices.rest.uriPrefix");
+        Context.removeProxyPrivilege(org.openmrs.util.PrivilegeConstants.GET_GLOBAL_PROPERTIES);
         if (StringUtils.isNotBlank(restUri)) {
             try {
                 URI uri = new URI(restUri);

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.ict4h.openmrs</groupId>
 	<artifactId>openmrs-atomfeed</artifactId>
-	<version>2.6.3</version>
+	<version>2.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>AtomFeed Module</name>
 	<description>Atomfeed publisher and consumer for OpenMRS.</description>


### PR DESCRIPTION
This PR fixes the feed API failing with Authenticated exception and throwing a 302 error with an invalid or no session. This PR brings in backward compatibility to ensure the feed consumers and libraries work as before on the older versions.

JIRA: https://bahmni.atlassian.net/browse/BAH-4681

Note:
- The ideal solution would be to refactor the feed-client to use the web-clients package and also refactor the controller to extend the BaseRestController base class so that exception is properly caught and appropriate response code is sent.
- This refactoring will be covered as part of this JIRA card: https://bahmni.atlassian.net/browse/BAH-4682